### PR TITLE
Updated some descriptions and fixed a broken link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A curated list of dotfiles resources. Inspired by the [awesome](https://github.c
 ### Using GNU Stow
 
 * [Using GNU Stow to manage your dotfiles](http://brandon.invergo.net/news/2012-05-26-using-gnu-stow-to-manage-your-dotfiles.html)
-* [Managing dotfiles with GNU Stow](http://taihen.org/managing-dotfiles-with-gnu-stow/)
+* [Managing dotfiles with GNU Stow](https://web.archive.org/web/20150304161240/http://taihen.org/managing-dotfiles-with-gnu-stow/)
 * [Managing Dotfile Symlinks with GNU Stow](http://spin.atomicobject.com/2014/12/26/manage-dotfiles-gnu-stow/)
 
 ### Using vcsh & mr
@@ -84,7 +84,7 @@ Tip: search for a filename on GitHub, e.g. [site:github.com .gitconfig](https://
 * [fresh](http://freshshell.com/) - Keep your dotfiles fresh. Fresh is a tool to source shell configuration (aliases, functions, etc) from others into your own configuration files.
 * [GNU Stow](http://www.gnu.org/software/stow/) - Symlink farm manager which takes distinct packages of software and/or data located in separate directories on the filesystem, and makes them appear to be installed in the same place.
 * [homeshick](https://github.com/andsens/homeshick) - Git dotfile synchronizer written in Bash.
-* [homesick](https://github.com/technicalpickles/homesick) - Your home directory is your castle. Don't leave your dotfiles behind ([post](http://technicalpickles.com/posts/never-leave-your-dotfiles-behind-again-with-homesick/)).
+* [homesick](https://github.com/technicalpickles/homesick) - Similar to homeshick, but written in Ruby. ([Post](http://technicalpickles.com/posts/never-leave-your-dotfiles-behind-again-with-homesick/)).
 * [mackup](https://github.com/lra/mackup) - Keep your application settings in sync (OS X/Linux).
 * [rcm](https://github.com/thoughtbot/rcm) - rc file (dotfile) management
 * [remote-dotfiles](https://www.npmjs.com/package/remote-dotfiles) - Describe your dotfiles configuration, tuned for and deploy to all your servers.


### PR DESCRIPTION
homesick vs. homeshick is a pretty important distinction since homesick has a Ruby dependency while homeshick, having all of homesick's functionality only relies on Bash.

In regards to fixing the link, the whole taihen.org site seems down, so I've included a link from the [WayBack Machine](https://archive.org/web/).