### PR TITLE
Add rootbeersoup's dotfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Title | Description | Focus
 [dev-setup](https://github.com/donnemartin/dev-setup) | Mac OS X development environment setup | Extensive setup of developer tools on OS X.
 [webpro's dotfiles](https://github.com/webpro/dotfiles) | macOS dotfiles | Bash, Homebrew, Brew Cask, Git, Node.js, Hammerspoon.
 [Overbryd's dotfiles](https://github.com/Overbryd/dotfiles) | macOS 0-100 bootstrap | macOS defaults, Bash, Homebrew, Casks, Git, Vim | Straightforward maintenance with a simple Makefile
+[rootbeersoup's dotfiles](https://github.com/rootbeersoup/dotfiles) | Effortless Bash, Vim and macOS configuration | A `curl \| sh` installer and a Makefile offer portable and effortless setup for either permanent or temporary configuration.
 
 ### Zsh
 


### PR DESCRIPTION
I'd like to add my dotfiles repo here. I think it has a couple unique features people might want to implement in their own, outside of the standard bootstrapping and installing Homebrew packages, etc:

* A `curl | sh` installer for single-command setup on a fresh machine.
* A flexible Makefile which allows for permanent or temporary configuration (great for configuring a shared computer).

I've geared my dotfiles so I can use them anywhere I need to, as effortlessly as possible. I wouldn't expect people to use my personal configs, but I think people could definitely take something away from how I offer setup flexibility.

Let me know what you think.