### PR TITLE
Adding bootstrap-macos to links as a new project supporting Bash and Zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ A collection of the most popular, well-maintained, and collaborative dotfiles re
 Title | Description | Focus
 :--|:--|:--
 [Bash it](https://github.com/Bash-it/bash-it) | Community bash framework. | Autocompletion, themes, aliases, custom functions. Well-structured framework.
+[Bootstrap for macOS (OS X / OSX) and Dotfiles](https://github.com/johnwyles/bootstrap-macos) | A set of many encompassing scripts to bootstrap a macOS (OS X / OSX) user environment with applications, application settings, dotfiles, custom masOS (OS X/OSX) settings, and various programming languages, editors (e.g. Atom, Sublime, VSCode), and their settings. This also includes beautification (e.g. color schemes, shell prompts, fonts, etc) settings from both Bash and Zsh using a number of terminals (e.g. Terminal.app, iTerm2, Hyper) settings. This also features a simplified `sh | curl` style installer for those wanting something ready out-of-the-box. | Homebrew, Bash-It, Oh My Zsh, mac OS (OS X/OSX), autocompletion, modern common programming languages.
 [Mathias’s dotfiles](https://github.com/mathiasbynens/dotfiles) | Sensible hacker defaults for macOS | Lots of goodness here, great collaborative community effort.
 [Maximum Awesome](https://github.com/square/maximum-awesome) | Config files for vim and tmux | Vim, tmux. Built for Mac OS X.
 [dev-setup](https://github.com/donnemartin/dev-setup) | Mac OS X development environment setup | Extensive setup of developer tools on OS X.
@@ -65,6 +66,7 @@ Title | Description | Focus
 
 Title | Description | Focus
 :--|:--|:--
+[Bootstrap for macOS (OS X / OSX) and Dotfiles](https://github.com/johnwyles/bootstrap-macos) | A set of many encompassing scripts to bootstrap a macOS (OS X / OSX) user environment with applications, application settings, dotfiles, custom masOS (OS X/OSX) settings, and various programming languages, editors (e.g. Atom, Sublime, VSCode), and their settings. This also includes beautification (e.g. color schemes, shell prompts, fonts, etc) settings from both Bash and Zsh using a number of terminals (e.g. Terminal.app, iTerm2, Hyper) settings. This also features a simplified `sh | curl` style installer for those wanting something ready out-of-the-box. | Homebrew, Bash-It, Oh My Zsh, mac OS (OS X/OSX), autocompletion, modern common programming languages.
 [thoughtbot dotfiles](https://github.com/thoughtbot/dotfiles) | Set of vim, zsh, git, and tmux configuration files | Zsh, vim, tmux, git, homebrew. Uses [rcm](https://github.com/thoughtbot/rcm).
 [oh-my-zsh](https://ohmyz.sh) | Community-driven framework for managing your zsh configuration. | Includes 200+ optional plugins (rails, git, OSX, hub, capistrano, brew, ant, php, python, etc), over 140 themes to spice up your morning, and an auto-update tool.
 [Prezto](https://github.com/sorin-ionescu/prezto) | The configuration framework for Zsh. | Enriches the command line interface environment with sane defaults, aliases, functions, auto completion, and prompt themes.


### PR DESCRIPTION
I have added the `bootstrap-macos` project which is about a little over a week of tailoring a number of various dotfile projects coming up with a more complete and updated and more generic setup of a macOS (OS X/OSX) user environment for software programmers / developers.  When setting up my new machine I found many of the dotfiles projects outdated and not using a cohesive approach across all of them such that they worked only 80% and would conflict with other projects.  I have spent much time sorting out the best features and settings from all of these projects and made the most up-to-date settings which are not in conflict and reflect the latest settings common for developers and programmers to date.

There are many features which include:
- Bash (Bash-It) with a lot of commonly used packages and color schemes active
- Zsh (Oh My Zsh) with tons of commonly useful plugins and themes enabled
- Atom with a ton of common language support as well as themes and settings
- Sublime text with sane default settings and a few pre-installed color schemes
- Updated sensible macOS (OS X/OSX) settings that developers often use
- Many of the most common programming languages and their support in all the above tooling installed and configured
- An `sh | curl` installer for users wanting a fresh setup

Please ignore that there have only been a few commits in this repository because I have been squashing all of these to create a cleaner history to start from when this project begins to gain adopters and users.  I am happy to help and let me know if there is anything you would like to amend to this PR if you have any further input. Thank you!