### PR TITLE
Add Pearl package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ A collection of the most popular, well-maintained, and collaborative dotfiles re
 - [homeshick](https://github.com/andsens/homeshick) - Git dotfile synchronizer written in Bash.
 - [homesick](https://github.com/technicalpickles/homesick) - Your home directory is your castle. Don't leave your dotfiles behind ([article](https://technicalpickles.com/posts/never-leave-your-dotfiles-behind-again-with-homesick)).
 - [mackup](https://github.com/lra/mackup) - Keep your application settings in sync (OS X/Linux).
+- [Pearl](https://github.com/pearl-core/pearl) - Package manager that allows to control, sync, share dotfiles as packages automatically activated during shells or editors startup. There is a wide range of packages already available in the [Official Pearl Hub](https://github.com/pearl-hub) (for Linux and OSX).
 - [rcm](https://github.com/thoughtbot/rcm) - rc file (dotfile) management
 - [SaltStack](https://www.saltstack.com) - Intelligent orchestration for the software-defined data center ([article](https://medium.com/@rawkode/managing-dotfiles-with-saltstack-eb600867073e)).
 - [themer](https://github.com/mjswensen/themer) - Manage and generate themes across your development tools from within your dotfiles.


### PR DESCRIPTION
Pearl which is getting more and more popular because of its simple and powerful way to manage dotfiles and programs of any kind. I would like to include into the list of dotfiles tools.

Thanks