### PR TITLE
Add lnko to tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ scripts to manage dotfiles and plugins.
 - [GNU Stow](http://www.gnu.org/software/stow/) - Symlink farm manager which takes distinct packages of software and/or
   data located in separate directories on the filesystem, and makes them appear to be installed in the same place.
 - [homeshick](https://github.com/andsens/homeshick) - Git dotfile synchronizer written in Bash.
+- [lnko](https://github.com/pgagnidze/lnko) - Simple stow-like dotfile linker.
 - [mackup](https://github.com/lra/mackup) - Keep your application settings in sync (macOS/Linux).
 - [Pearl](https://github.com/pearl-core/pearl) - Package manager that allows to control, sync, share dotfiles as
   packages automatically activated during shells or editors startup. There is a wide range of packages already


### PR DESCRIPTION
Add [lnko](https://github.com/pgagnidze/lnko) - a simple stow-like dotfile linker.