### PR TITLE
Add OpenBoot - Mac dev environment manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ scripts to manage dotfiles and plugins.
   data located in separate directories on the filesystem, and makes them appear to be installed in the same place.
 - [homeshick](https://github.com/andsens/homeshick) - Git dotfile synchronizer written in Bash.
 - [mackup](https://github.com/lra/mackup) - Keep your application settings in sync (macOS/Linux).
+- [OpenBoot](https://github.com/openbootdotdev/openboot) - Mac dev environment manager that captures and restores Homebrew packages, dotfiles, shell configuration, and macOS preferences via interactive TUI.
 - [Pearl](https://github.com/pearl-core/pearl) - Package manager that allows to control, sync, share dotfiles as
   packages automatically activated during shells or editors startup. There is a wide range of packages already
   available. in the [Official Pearl Hub](https://github.com/pearl-hub) (for Linux and OSX).


### PR DESCRIPTION
## OpenBoot

[OpenBoot](https://github.com/openbootdotdev/openboot) is an open-source Mac dev environment manager with dotfiles capture and restore.

**What it does:**
- Captures dotfiles, shell config (with sentinel blocks to avoid duplicate entries), Homebrew packages/casks, git settings, and macOS preferences
- Restores the full environment with one command
- Interactive TUI built with Charmbracelet/Bubble Tea
- Fits the "Tools" section alongside chezmoi, mackup, etc.

**Details:**
- MIT licensed, zero telemetry
- Install: `brew install openbootdotdev/tap/openboot`
- GitHub: https://github.com/openbootdotdev/openboot