### PR TITLE
Add cloudprobe/dotfiles to Zsh section

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ scripts to manage dotfiles and plugins.
 | [Luke's voidrice](https://github.com/LukeSmithxyz/voidrice)   | My dotfiles (deployed by LARBS)                                          | Zsh, vim/nvim, zsf                                                                                                                               |
 | [2KAbhishek's dots2k](https://github.com/2KAbhishek/dots2k)   | Passionately crafted, extensible dotfiles with multi platform support    | CLI tools at core, with extensions for different platforms (windows/mac/android), editors and window managers                                    |
 | [Zim](https://github.com/zimfw/zimfw)                         | Modular, customizable, and blazing fast Zsh framework                    | Zim is a Zsh configuration framework that bundles a plugin manager, useful modules, and a wide variety of themes, without compromising on speed. |
+| [cloudprobe's dotfiles](https://github.com/cloudprobe/dotfiles) | Zero-to-productive dotfiles for macOS — ZSH + Starship + Claude Code    | Zsh, zinit, Starship, Claude Code, Kubernetes, AWS, Terraform, Go                                                                                |
 
 ### Fish
 


### PR DESCRIPTION
## What

Adds [cloudprobe/dotfiles](https://github.com/cloudprobe/dotfiles) to the Zsh section.

## Why it fits

- **Zsh via zinit** — lazy-loading plugin manager, no oh-my-zsh, <1s shell startup
- **Starship prompt** — shows Git, Kubernetes context, AWS profile, Terraform workspace, Go, Python
- **Claude Code config** — hierarchical global config with rules, hooks, agents, and a team-ready project template (the main differentiator vs other entries)
- **Production/infra focus** — built for engineers working daily with Kubernetes, AWS, Terraform, and Go
- **One-command install** — `make install` bootstraps everything including all Brew dependencies

## Checklist

- [x] Entry follows existing table format
- [x] Link points to public GitHub repo
- [x] Description is concise
- [x] Repo is actively maintained (last commit today)