### PR TITLE
Add pro-terminal-setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ scripts to manage dotfiles and plugins.
 - [mackup][64] - Keep your application settings in sync (macOS/Linux).
 - [OpenBoot][65] - Mac dev environment manager that captures and restores Homebrew packages, dotfiles, shell
   configuration, and macOS preferences via interactive TUI.
+- [pro-terminal-setup](https://github.com/mathewjustin/pro-terminal-setup) - Portable Ghostty/zsh terminal setup with
+  Homebrew install, backups, doctor/uninstall commands, and Kubernetes/tmux helpers.
 - [rcm][37] - rc file (dotfile) management.
 - [rotz][66] - Fully cross-platform dotfile manager and dev environment bootstrapper written in Rust.
 - [themer][67] - Manage and generate themes across your development tools from within your dotfiles.


### PR DESCRIPTION
Adds pro-terminal-setup, a small Homebrew-installable Ghostty/zsh terminal setup with backup, doctor, uninstall, and Kubernetes/tmux helpers.